### PR TITLE
Bedesten: Enforce upstream page size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,12 +240,12 @@ Tüm 12 mevzuat türünde başlık ve içerik araması yapar.
 * `mevzuat_tur`: Mevzuat türü filtresi (KANUN, KHK, TUZUK, YONETMELIK, CB_KARARNAME, CB_KARAR, CB_YONETMELIK, CB_GENELGE, KKY, UY, TEBLIGLER, MULGA)
 * `basliktaAra`: Sadece başlıkta ara (varsayılan: true)
 * `tamCumle`: Tam cümle eşleşmesi (varsayılan: false)
-* `resmi_gazete_tarihi`: Resmi Gazete tarihi filtresi (GG/AA/YYYY)
+* `resmi_gazete_tarihi_start`, `resmi_gazete_tarihi_end`: Resmi Gazete tarih aralığı filtresi (GG/AA/YYYY)
 * `resmi_gazete_sayisi`: Resmi Gazete sayısı filtresi
-* `page`, `page_size`: Sayfalama
+* `page`, `page_size`: Sayfalama (`page_size` varsayılan 20, en fazla 20; Bedesten API daha büyük değerleri reddeder)
 
 #### **`get_mevzuat_content`** - Tam Metin Getirme
-Bir mevzuatın tam metnini Markdown formatında getirir.
+Bir mevzuatın tam metnini düz metin olarak getirir.
 * `mevzuat_id`: Mevzuat ID'si (`search_mevzuat` sonucundan alınır, mevzuat numarası değildir)
 
 #### **`search_within_mevzuat`** - Madde Bazında Arama

--- a/bedesten_client.py
+++ b/bedesten_client.py
@@ -39,6 +39,8 @@ HEADERS = {
 }
 
 APP_NAME = "UyapMevzuat"
+BEDESTEN_DEFAULT_PAGE_SIZE = 20
+BEDESTEN_MAX_PAGE_SIZE = 20
 
 
 def _wrap(data: dict) -> dict:
@@ -146,7 +148,7 @@ class BedestenClient:
         resmi_gazete_tarihi_end: Optional[str] = None,
         resmi_gazete_sayisi: Optional[str] = None,
         page: int = 1,
-        page_size: int = 25,
+        page_size: int = BEDESTEN_DEFAULT_PAGE_SIZE,
         sort_field: str = "RESMI_GAZETE_TARIHI",
         sort_direction: str = "desc",
     ) -> BedSearchResult:
@@ -164,10 +166,16 @@ class BedestenClient:
             resmi_gazete_tarihi_end: End date filter (DD/MM/YYYY). Converted to ISO 8601 for API.
             resmi_gazete_sayisi: Official Gazette number filter.
             page: Page number (1-based)
-            page_size: Results per page
+            page_size: Results per page. bedesten.adalet.gov.tr rejects values over 20.
             sort_field: RESMI_GAZETE_TARIHI, MEVZUAT_ADI, MEVZUAT_NO, etc.
             sort_direction: asc or desc
         """
+        if page_size < 1 or page_size > BEDESTEN_MAX_PAGE_SIZE:
+            return BedSearchResult(
+                error_message=f"page_size must be between 1 and {BEDESTEN_MAX_PAGE_SIZE} for bedesten.adalet.gov.tr",
+                query_used=phrase,
+            )
+
         inner: Dict[str, Any] = {
             "pageSize": page_size,
             "pageNumber": page,

--- a/mevzuat_mcp_server.py
+++ b/mevzuat_mcp_server.py
@@ -40,6 +40,11 @@ app = FastMCP(
     instructions="MCP server for Turkish legislation search and content retrieval. "
     "Two data sources: mevzuat.gov.tr (21 tools, Playwright-based) and bedesten.adalet.gov.tr (5 tools, pure REST). "
     "\n\n"
+    "== Tool choice quick guide ==\n"
+    "If the user provides an official legislation number such as 3065, 5237, 6102, or 6362, use bedesten search_mevzuat with mevzuat_no. "
+    "If the user provides a topic/title phrase, use either the relevant mevzuat.gov.tr type-specific search tool or bedesten search_mevzuat with mevzuat_adi/phrase. "
+    "After search_mevzuat, use the returned mevzuatId with get_mevzuat_content, search_within_mevzuat, or get_mevzuat_madde_tree; mevzuatId is not the legislation number. "
+    "\n\n"
     "== mevzuat.gov.tr tools (21 tools) ==\n"
     "9 legislation types: Kanun, KHK, Tüzük, Kurum Yönetmeliği, Tebliğ, CB Kararnamesi, CB Kararı, CB Yönetmeliği, CB Genelgesi. "
     "Each type has search and search_within tools. search_within supports keyword (AND/OR/NOT) and semantic search (OPENROUTER_API_KEY). "
@@ -47,6 +52,7 @@ app = FastMCP(
     "\n\n"
     "== bedesten.adalet.gov.tr tools (5 tools) ==\n"
     "Alternative API, no auth needed, supports 12 legislation types and Solr/Lucene search operators. "
+    "page_size must be 1-20 because the upstream API rejects larger pages. "
     "Tools: search_mevzuat (unified search with type filter, supports law number search), "
     "get_mevzuat_content (full text), search_within_mevzuat (article keyword search), "
     "get_mevzuat_gerekce (law rationale/gerekçe), get_mevzuat_madde_tree (article tree/TOC). "
@@ -1884,7 +1890,12 @@ async def search_within_cbgenelge(
 # Bedesten API tools (bedesten.adalet.gov.tr - alternative, no auth needed)
 # ============================================================================
 
-from bedesten_client import BedestenClient, _strip_html
+from bedesten_client import (
+    BEDESTEN_DEFAULT_PAGE_SIZE,
+    BEDESTEN_MAX_PAGE_SIZE,
+    BedestenClient,
+    _strip_html,
+)
 from bedesten_models import BedMaddeNode
 
 bedesten_client = BedestenClient(cache_ttl=3600, enable_cache=True)
@@ -2014,7 +2025,12 @@ async def search_mevzuat(
         description="Official Gazette issue number filter. E.g., '28513'.",
     ),
     page: int = Field(1, ge=1, description="Page number (1-based, default: 1)"),
-    page_size: int = Field(25, ge=1, le=100, description="Results per page (1-100, default: 25)"),
+    page_size: int = Field(
+        BEDESTEN_DEFAULT_PAGE_SIZE,
+        ge=1,
+        le=BEDESTEN_MAX_PAGE_SIZE,
+        description=f"Results per page (1-{BEDESTEN_MAX_PAGE_SIZE}, default: {BEDESTEN_DEFAULT_PAGE_SIZE}). bedesten.adalet.gov.tr rejects larger values.",
+    ),
 ) -> str:
     """
     Search or browse all Turkish legislation on bedesten.adalet.gov.tr.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "mevzuat-mcp"
 version = "1.0.0"
-description = "MCP Server for Turkish Legislation - 18 tools for comprehensive access to Turkish laws, decrees, regulations and circulars"
+description = "MCP Server for Turkish Legislation - 26 tools for comprehensive access to Turkish laws, decrees, regulations and circulars"
 readme = "README.md"
 requires-python = ">=3.11"
 license = {text = "MIT"}


### PR DESCRIPTION
## What This PR Does

### The Problem

While running this MCP server on my own deployment, I noticed that the Bedesten search tool advertises and defaults to result page sizes that the upstream Bedesten service does not accept. The upstream API rejects requests where `pageSize` is greater than 20, but `search_mevzuat` exposed a default of 25 and a schema maximum of 100.

### The Solution

This PR keeps the change intentionally small and aligns the MCP server with the upstream service behavior:

- Sets the Bedesten default page size to 20.
- Adds a Bedesten-specific maximum page size constant of 20.
- Validates Bedesten `page_size` before sending the upstream request.
- Updates the MCP tool schema so agents no longer choose invalid `page_size` values.
- Corrects the README parameter names and return description for the Bedesten tools.
- Updates the package description from 18 tools to the current 26 tools.

## What Changes for Users

- **For MCP users and agents:** `search_mevzuat` no longer defaults to an upstream-invalid page size.
- **For maintainers:** the documented Bedesten limits now match the source service, which should reduce avoidable failed tool calls.

---

## Technical Summary

| Area | Change |
| --- | --- |
| Commit | `feat(bedesten): enforce upstream page size limit` |
| Files changed | `bedesten_client.py`, `mevzuat_mcp_server.py`, `README.md`, `pyproject.toml` |
| Key decision | Bedesten page size is capped at 20 because the upstream API rejects larger values. |

## Validation

- [x] Verified the upstream Bedesten API accepts `pageSize=20`.
- [x] Verified the upstream Bedesten API rejects `pageSize=21` with: `Kayıt sayısı 20'den fazla olamaz`.
- [x] Ran Python syntax validation:

```bash
python3 -m py_compile bedesten_client.py mevzuat_mcp_server.py
```
